### PR TITLE
Add support for etag/if-none-match

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ curl  -H "OCS-APIRequest: true" \
 | type  | string | Can be one of `link`, `settings` or `quota`; see [this issue](https://github.com/nextcloud/external/issues/7) for details |
 | icon  | string | Full URL of the icon that should be shown next to the name of the link |
 
+### ETag / If-None-Match
+
+The API provides an ETag for the sites array. In case the ETag matches the given value, a `304 Not Modified` is delivered together with an empty response body.
+
 ### Capability
 
 The app registers a capability, so clients can check that before making the actual OCS request:

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -74,7 +74,14 @@ class APIController extends OCSController {
 			$site['icon'] = $this->url->getAbsoluteURL($this->url->imagePath('external', $site['icon']));
 			$sites[] = $site;
 		}
-		return new DataResponse($sites);
+
+
+		$etag = md5(json_encode($sites));
+		if ($this->request->getHeader('If-None-Match') === $etag) {
+			return new DataResponse([], Http::STATUS_NOT_MODIFIED);
+		}
+
+		return new DataResponse($sites, Http::STATUS_OK, ['ETag' => $etag]);
 	}
 
 	/**


### PR DESCRIPTION
```
curl -k -v https://admin:admin@nextcloud12.local/ocs/v2.php/apps/external/api/v1
...
< HTTP/1.1 200 OK
< ETag: d751713988987e9331980363e24189ce
< Content-Length: 138
...
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message>OK</message>
 </meta>
 <data/>
</ocs>
```

```
curl -k -v -H "If-None-Match: d751713988987e9331980363e24189ce" https://admin:admin@nextcloud12.local/ocs/v2.php/apps/external/api/v1
...
> If-None-Match: d751713988987e9331980363e24189ce
> 
< HTTP/1.1 304 Not Modified
...
* Excess found in a non pipelined read: excess = 132 url = /ocs/v2.php/apps/external/api/v1 (zero-length body)
```

Fix #13 

@mario please confirm