### PR TITLE
Copy the method instead of including tones of JS files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ source_dir=$(build_dir)/source
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
-version+=2.0.0
+version+=2.0.1
 
 all: appstore
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@ More information is available in the External sites documentation.]]></descripti
 	<bugs>https://github.com/nextcloud/external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/external.git</repository>
 
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<namespace>External</namespace>
 
 	<dependencies>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -25,7 +25,6 @@
 
 style('external', 'style');
 script('external', 'admin');
-script('settings', 'apps');
 
 /** @var array $_ */
 /** @var \OCP\IL10N $l */


### PR DESCRIPTION
Fix #21 

The problem is correctly including the pre-requirement marked JS is not enough. It then continues to spam with the missing handlebars, etc because the file is executing stuff instead of just defining the methods/classes.

So I thought it was easier to just copy the single method over