### PR TITLE
Add proper frame-src

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -62,6 +62,7 @@ class PageController extends Controller {
 
 			$policy = new ContentSecurityPolicy();
 			$policy->addAllowedChildSrcDomain('*');
+			$policy->addAllowedFrameDomain('*');
 			$response->setContentSecurityPolicy($policy);
 
 			return $response;


### PR DESCRIPTION
Chrome requires the frame-src be set otherwise the external page will simply not load.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>