### PR TITLE
Introduce a new UI to be prepared for more options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,34 @@
-.site-url {
-	width: 250px;
+.site-name, .site-url {
+	width: 35%;
+}
+
+.site-lang, .site-icon, .site-device, .site-type {
+	width: 20%;
+}
+
+#external label span {
+	display: inline-block;
+	min-width: 120px;
+}
+
+#external ul.external_sites li {
+	padding: 5px 12px 20px;
+}
+
+#external ul.external_sites li.saving {
+	box-shadow: inset 2px 0 #CCCCCC;
+}
+
+#external ul.external_sites li.saved {
+	box-shadow: inset 2px 0 #00AA00;
+}
+
+#external ul.external_sites li.failure {
+	box-shadow: inset 2px 0 #AA0000;
+}
+
+#external ul.external_sites li h3 {
+	cursor: pointer;
 }
 
 #loading_sites {
@@ -12,7 +41,7 @@
 }
 
 .invalid-value {
-	border-color: red !important;
+	border-color: #AA0000 !important;
 }
 
 li:hover .delete-button {

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -100,10 +100,11 @@ class APIController extends OCSController {
 		array_unshift($languages, ['code' => '', 'name' => $this->l->t('All languages')]);
 
 		$types = [
-			['type' => SitesManager::TYPE_LINK, 'name' => $this->l->t('Normal')],
-			['type' => SitesManager::TYPE_SETTING, 'name' => $this->l->t('Setting')],
-			['type' => SitesManager::TYPE_QUOTA, 'name' => $this->l->t('Quota')],
+			['type' => SitesManager::TYPE_LINK, 'name' => $this->l->t('Header')],
+			['type' => SitesManager::TYPE_SETTING, 'name' => $this->l->t('Setting menu')],
+			['type' => SitesManager::TYPE_QUOTA, 'name' => $this->l->t('User quota')],
 		];
+
 		$devices = [
 			['device' => SitesManager::DEVICE_ALL, 'name' => $this->l->t('All devices')],
 			['device' => SitesManager::DEVICE_ANDROID, 'name' => $this->l->t('Only in the Android app')],
@@ -134,17 +135,17 @@ class APIController extends OCSController {
 		try {
 			return new DataResponse($this->sitesManager->addSite($name, $url, $lang, $type, $device, $icon));
 		} catch (InvalidNameException $e) {
-			return new DataResponse($this->l->t('The given name is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given label is invalid'), 'field' => 'name'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidURLException $e) {
-			return new DataResponse($this->l->t('The given URL is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given URL is invalid'), 'field' => 'url'], Http::STATUS_BAD_REQUEST);
 		} catch (LanguageNotFoundException $e) {
-			return new DataResponse($this->l->t('The given language does not exist'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given language does not exist'), 'field' => 'lang'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidTypeException $e) {
-			return new DataResponse($this->l->t('The given type is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given type is invalid'), 'field' => 'type'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidDeviceException $e) {
-			return new DataResponse($this->l->t('The given device is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given device is invalid'), 'field' => 'device'], Http::STATUS_BAD_REQUEST);
 		} catch (IconNotFoundException $e) {
-			return new DataResponse($this->l->t('The given icon does not exist'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given icon does not exist'), 'field' => 'icon'], Http::STATUS_BAD_REQUEST);
 		}
 	}
 
@@ -162,19 +163,19 @@ class APIController extends OCSController {
 		try {
 			return new DataResponse($this->sitesManager->updateSite($id, $name, $url, $lang, $type, $device, $icon));
 		} catch (SiteNotFoundException $e) {
-			return new DataResponse($this->l->t('The site does not exist'), Http::STATUS_NOT_FOUND);
+			return new DataResponse(['error' => $this->l->t('The site does not exist'), 'field' => 'site'], Http::STATUS_NOT_FOUND);
 		} catch (InvalidNameException $e) {
-			return new DataResponse($this->l->t('The given name is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given label is invalid'), 'field' => 'name'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidURLException $e) {
-			return new DataResponse($this->l->t('The given URL is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given URL is invalid'), 'field' => 'url'], Http::STATUS_BAD_REQUEST);
 		} catch (LanguageNotFoundException $e) {
-			return new DataResponse($this->l->t('The given language does not exist'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given language does not exist'), 'field' => 'lang'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidTypeException $e) {
-			return new DataResponse($this->l->t('The given type is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given type is invalid'), 'field' => 'type'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidDeviceException $e) {
-			return new DataResponse($this->l->t('The given device is invalid'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given device is invalid'), 'field' => 'device'], Http::STATUS_BAD_REQUEST);
 		} catch (IconNotFoundException $e) {
-			return new DataResponse($this->l->t('The given icon does not exist'), Http::STATUS_BAD_REQUEST);
+			return new DataResponse(['error' => $this->l->t('The given icon does not exist'), 'field' => 'icon'], Http::STATUS_BAD_REQUEST);
 		}
 	}
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -43,48 +43,86 @@ script('external', 'admin');
 
 		<script type="text/template" id="site-template">
 			<li data-site-id="{{id}}">
-				<input type="text" class="site-name trigger-save" name="site-name" value="{{name}}" placeholder="<?php p($l->t('Name')); ?>" />
-				<input type="text" class="site-url trigger-save"  name="site-url" value="{{url}}" placeholder="<?php p($l->t('URL')); ?>" />
-				<select class="site-icon trigger-save">
-					{{#each (getIcons icon)}}
-						{{#if (isSelected icon ../icon)}}
-							<option value="{{icon}}" selected="selected">{{name}}</option>
-						{{else}}
-							<option value="{{icon}}">{{name}}</option>
-						{{/if}}
-					{{/each}}
-				</select>
-				<select class="site-lang trigger-save">
-					{{#each (getLanguages lang)}}
-						{{#if (isSelected code ../lang)}}
-							<option value="{{code}}" selected="selected">{{name}}</option>
-						{{else}}
-							<option value="{{code}}">{{name}}</option>
-						{{/if}}
-					{{/each}}
-				</select>
-				<select class="site-type trigger-save">
-					{{#each (getTypes type)}}
-						{{#if (isSelected type ../type)}}
-							<option value="{{type}}" selected="selected">{{name}}</option>
-						{{else}}
-							<option value="{{type}}">{{name}}</option>
-						{{/if}}
-					{{/each}}
-				</select>
-				<select class="site-device trigger-save">
-					{{#each (getDevices device)}}
-						{{#if (isSelected device ../device)}}
-							<option value="{{device}}" selected="selected">{{name}}</option>
-						{{else}}
-							<option value="{{device}}">{{name}}</option>
-						{{/if}}
-					{{/each}}
-				</select>
-				<img class="svg action delete-button" src="<?php p(image_path('core', 'actions/delete.svg')); ?>" title="<?php p($l->t('Remove site')); ?>" />
-				<img class="svg action saving hidden" src="<?php p(image_path('core', 'loading-small.gif')); ?>" alt="<?php p($l->t('Saving')); ?>" />
-				<img class="svg action saved hidden" src="<?php p(image_path('core', 'actions/checkmark-color.svg')); ?>" alt="<?php p($l->t('Saved!')); ?>" />
-				<img class="svg action failure hidden" src="<?php p(image_path('core', 'actions/error-color.svg')); ?>" alt="<?php p($l->t('Can not save site')); ?>" />
+				<h3>
+					{{name}} <small>{{url}}</small>
+					<img class="svg action delete-button" src="<?php p(image_path('core', 'actions/delete.svg')); ?>" title="<?php p($l->t('Remove site')); ?>">
+				</h3>
+
+				<div class="options hidden">
+					<div>
+						<label>
+							<span><?php p($l->t('Label')) ?></span>
+							<input type="text" class="site-name trigger-save" name="site-name" value="{{name}}" placeholder="<?php p($l->t('Name')); ?>">
+						</label>
+					</div>
+
+					<div>
+						<label>
+							<span><?php p($l->t('URL')) ?></span>
+							<input type="text" class="site-url trigger-save"  name="site-url" value="{{url}}" placeholder="<?php p($l->t('URL')); ?>">
+						</label>
+					</div>
+
+					<div>
+						<label>
+							<span><?php p($l->t('Language')) ?></span>
+							<select class="site-lang trigger-save">
+								{{#each (getLanguages lang)}}
+								{{#if (isSelected code ../lang)}}
+								<option value="{{code}}" selected="selected">{{name}}</option>
+								{{else}}
+								<option value="{{code}}">{{name}}</option>
+								{{/if}}
+								{{/each}}
+							</select>
+						</label>
+					</div>
+
+					<div>
+						<label>
+							<span><?php p($l->t('Devices')) ?></span>
+							<select class="site-device trigger-save">
+								{{#each (getDevices device)}}
+								{{#if (isSelected device ../device)}}
+								<option value="{{device}}" selected="selected">{{name}}</option>
+								{{else}}
+								<option value="{{device}}">{{name}}</option>
+								{{/if}}
+								{{/each}}
+							</select>
+						</label>
+					</div>
+
+					<div>
+						<label>
+							<span><?php p($l->t('Icon')) ?></span>
+							<select class="site-icon trigger-save">
+								{{#each (getIcons icon)}}
+								{{#if (isSelected icon ../icon)}}
+								<option value="{{icon}}" selected="selected">{{name}}</option>
+								{{else}}
+								<option value="{{icon}}"><img class="svg action delete-button" src="<?php p(image_path('core', 'actions/delete.svg')); ?>" title="<?php p($l->t('Remove site')); ?>"> {{name}}</option>
+								{{/if}}
+								{{/each}}
+							</select>
+						</label>
+					</div>
+
+					<div>
+						<label>
+							<span><?php p($l->t('Position')) ?></span>
+							<select class="site-type trigger-save">
+								{{#each (getTypes type)}}
+								{{#if (isSelected type ../type)}}
+								<option value="{{type}}" selected="selected">{{name}}</option>
+								{{else}}
+								<option value="{{type}}">{{name}}</option>
+								{{/if}}
+								{{/each}}
+							</select>
+						</label>
+					</div>
+				</div>
 			</li>
 		</script>
 


### PR DESCRIPTION
The change needs to be done in preparation for #26 
There is no way we can fit more options into the old single line table layout.

@nextcloud/designers can someone take a quick look if this is okay?

### Before
>  ![Before](https://github.com/nextcloud/external/blob/893f60d3995f5ecfeec8535e0e9ece798a48e653/docs/admin-settings.png?raw=true)

### After
> ![After](https://cloud.githubusercontent.com/assets/213943/26577066/5e2b10f8-452b-11e7-8680-14c74f7c787b.png)
