### PR TITLE
[stable12] Fix infinite redirect when the app is the default app

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,6 +21,7 @@
 
 return [
 	'routes' => [
+		['name' => 'page#showDefaultPage', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'page#showPage', 'url' => '/{id}', 'verb' => 'GET'],
 	],
 	'ocs' => [

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -27,21 +27,47 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
 
 class PageController extends Controller {
 
+	/** @var IConfig */
+	protected $config;
 	/** @var SitesManager */
 	protected $sitesManager;
 
 	/** @var INavigationManager */
 	protected $navigationManager;
+	/** @var IURLGenerator */
+	protected $url;
+	/** @var IL10N */
+	protected $l10n;
 
-	public function __construct($appName, IRequest $request, INavigationManager $navigationManager, SitesManager $sitesManager) {
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IConfig $config
+	 * @param INavigationManager $navigationManager
+	 * @param SitesManager $sitesManager
+	 * @param IURLGenerator $url
+	 * @param IL10N $l10n
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								IConfig $config,
+								INavigationManager $navigationManager,
+								SitesManager $sitesManager,
+								IURLGenerator $url,
+								IL10N $l10n) {
 		parent::__construct($appName, $request);
+		$this->config = $config;
 		$this->sitesManager = $sitesManager;
 		$this->navigationManager = $navigationManager;
+		$this->url = $url;
+		$this->l10n = $l10n;
 	}
 
 	/**
@@ -54,20 +80,59 @@ class PageController extends Controller {
 	public function showPage($id) {
 		try {
 			$site = $this->sitesManager->getSiteById($id);
-			$this->navigationManager->setActiveEntry('external_index' . $id);
-
-			$response = new TemplateResponse('external', 'frame', [
-				'url' => $site['url'],
-			], 'user');
-
-			$policy = new ContentSecurityPolicy();
-			$policy->addAllowedChildSrcDomain('*');
-			$policy->addAllowedFrameDomain('*');
-			$response->setContentSecurityPolicy($policy);
-
-			return $response;
+			return $this->createResponse($id, $site);
 		} catch (SiteNotFoundException $e) {
 			return new RedirectResponse(\OC_Util::getDefaultPageUrl());
 		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * This is used when the app is set as default app
+	 *
+	 * @return TemplateResponse|RedirectResponse
+	 */
+	public function showDefaultPage() {
+		// Show first available page when there is one
+		$sites = $this->sitesManager->getSitesToDisplay();
+		if (!empty($sites)) {
+			reset($sites);
+			$id = key($sites);
+			return $this->createResponse($id, $sites[$id]);
+		}
+
+		// Redirect to default page when it's not the external sites app
+		if ($this->config->getSystemValue('defaultapp', 'files') !== 'external') {
+			return new RedirectResponse(\OC_Util::getDefaultPageUrl());
+		}
+
+		// Fall back to the files app
+		if ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true ||
+			getenv('front_controller_active') === 'true') {
+			return new RedirectResponse($this->url->getAbsoluteURL('/apps/files/'));
+		}
+		return new RedirectResponse($this->url->getAbsoluteURL('/index.php/apps/files/'));
+	}
+
+	/**
+	 * @param int $id
+	 * @param array $site
+	 * @return RedirectResponse|TemplateResponse
+	 */
+	protected function createResponse($id, array $site) {
+		$this->navigationManager->setActiveEntry('external_index' . $id);
+
+		$response = new TemplateResponse('external', 'frame', [
+			'url' => $site['url'],
+		], 'user');
+
+		$policy = new ContentSecurityPolicy();
+		$policy->addAllowedChildSrcDomain('*');
+		$policy->addAllowedFrameDomain('*');
+		$response->setContentSecurityPolicy($policy);
+
+		return $response;
 	}
 }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -31,6 +31,7 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 
 class PageController extends Controller {
 


### PR DESCRIPTION
I backported #51 but then get this:

```
Typ: OCP\AppFramework\QueryException
Nachricht: Could not resolve appName! Class appName does not exist
Datei: /srv/projects/server/lib/private/AppFramework/Utility/SimpleContainer.php
Zeile: 102
```

@nickvergessen Any idea why stable12 works fine with `$appName` but this branch not?