### PR TITLE
[stable13] Fix personal settings after removing a quota link

### DIFF
--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -55,6 +55,10 @@ class Personal implements ISettings {
 			}
 		}
 
+		if (empty($quotaLink)) {
+			return new TemplateResponse('external', 'quota', [], '');
+		}
+
 		$url = $quotaLink['url'];
 		if (!$quotaLink['redirect']) {
 			$url = $this->url->linkToRoute('external.site.showPage', ['id'=> $quotaLink['id']]);

--- a/templates/quota.php
+++ b/templates/quota.php
@@ -20,7 +20,9 @@
  */
 
 script('external', 'quota-personal');
+if (isset($_['quotaLink'])) {
 ?>
 <div id="quota_link" class="section hidden">
 	<a class="button" href="<?php p($_['quotaLink']); ?>"><?php p($_['quotaName']); ?></a>
 </div>
+<?php }


### PR DESCRIPTION
Fix #104 


Steps:
1. Add a site for "quota link"
2. Move it to the header menu
3. Open personal settings

Breaks only on 13, 14 is fine because settings modules are not cached anymore.