### PR TITLE
remove 'organization' category

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,6 @@ More information is available in the External sites documentation.]]></descripti
 
 	<category>customization</category>
 	<category>integration</category>
-	<category>organization</category>
 	<category>tools</category>
 
 	<screenshot>https://github.com/nextcloud/external/raw/master/docs/admin-settings.png</screenshot>


### PR DESCRIPTION
While, I suppose, the external sites can be used to organize things I just don't think it is a primary purpose that fits with the tasks, calendar or polls apps.

And yes, a few other apps have to be removed there, too, I'm making a few PR's :D