### PR TITLE
Added Auth fields

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ More information is available in the External sites documentation.]]></descripti
 	<namespace>External</namespace>
 
 	<dependencies>
-		<nextcloud min-version="16" max-version="17" />
+		<nextcloud min-version="18" max-version="18" />
 	</dependencies>
 
 	<settings>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,11 +28,11 @@ More information is available in the External sites documentation.]]></descripti
 	<bugs>https://github.com/nextcloud/external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/external.git</repository>
 
-	<version>3.4.0</version>
+	<version>3.4.0.1</version>
 	<namespace>External</namespace>
 
 	<dependencies>
-		<nextcloud min-version="17" max-version="17" />
+		<nextcloud min-version="16" max-version="17" />
 	</dependencies>
 
 	<settings>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,7 +28,7 @@ More information is available in the External sites documentation.]]></descripti
 	<bugs>https://github.com/nextcloud/external/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/external.git</repository>
 
-	<version>3.4.0.1</version>
+	<version>3.5.0</version>
 	<namespace>External</namespace>
 
 	<dependencies>

--- a/js/admin.js
+++ b/js/admin.js
@@ -43,7 +43,7 @@
 	});
 
 	Handlebars.registerHelper('getTypes', function() {
-		return OCA.External.App.availableTypes;
+		return OCA.External.App.availableTypes;z
 	});
 
 	Handlebars.registerHelper('getDevices', function() {
@@ -60,6 +60,10 @@
 		defaults: {
 			name: '',
 			url: '',
+      loginurl: '',
+      login: '',
+      password: '',
+      headers: '',
 			lang: '',
 			type: 'link',
 			device: '',
@@ -96,6 +100,11 @@
 		_renderSite: function(data) {
 			data.nameTXT = t('external', 'Name');
 			data.urlTXT = t('external', 'URL');
+      data.authTXT = t('external', 'Auth');
+      data.loginUrlTXT = t('external', 'LoginUrl');
+      data.loginTXT = t('external', 'Login');
+      data.passwordTXT = t('external', 'Password');
+      data.headersTXT = t('external', 'Headers');
 			data.languageTXT = t('external', 'Language');
 			data.groupsTXT = t('external', 'Groups');
 			data.devicesTXT = t('external', 'Devices');
@@ -225,6 +234,10 @@
 				data = {
 					name: $site.find('.site-name').val(),
 					url: $site.find('.site-url').val(),
+          loginurl: $site.find('.site-loginurl').val(),
+          login: $site.find('.site-login').val(),
+          password: $site.find('.site-password').val(),
+          headers: $site.find('.site-headers').val(),
 					lang: $site.find('.site-lang').val(),
 					type: $site.find('.site-type').val(),
 					device: $site.find('.site-device').val(),

--- a/js/external.js
+++ b/js/external.js
@@ -13,4 +13,34 @@ $(document).ready(function () {
 
 	document.getElementById('ifm').onload = resizeIframe;
 	window.onresize = resizeIframe;
+
+  var credentials = {
+		"username": $("#external_username").val(),
+		"password": $("#external_password").val(),
+	};
+
+	$.ajax({
+		url: $("#external_loginurl").val(),
+		type: "POST",
+		dataType: 'json',
+		/*
+		contentType: 'application/json',
+		data: JSON.stringify(credentials),
+		processData: false,
+		*/
+		data: credentials,
+		xhrFields: {
+			'withCredentials': true
+		},
+		headers: JSON.parse($("#external_headers").val()),
+		success: function(data){
+				$("#ifm").attr('src', $("#external_url").val());
+				//var win = window.open($("#external_url").val());
+		},
+		error: function(xhr, text, error) {
+			alert(text + ":" + error);
+		}
+	});
+
+
 });

--- a/js/templates.js
+++ b/js/templates.js
@@ -113,6 +113,32 @@ templates['site'] = template({"1":function(container,depth0,helpers,partials,dat
     + "\" placeholder=\""
     + alias4(((helper = (helper = helpers.urlTXT || (depth0 != null ? depth0.urlTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"urlTXT","hash":{},"data":data}) : helper)))
     + "\">\n	<a class=\"icon-more\" href=\"#\"></a>\n\n	<div class=\"options hidden\">\n		<div>\n			<label>\n				<span>"
+
+    + alias4(((helper = (helper = helpers.authTXT || (depth0 != null ? depth0.authTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"authTXT","hash":{},"data":data}) : helper)))
+    + "</span>\n <input type=\"text\" class=\"site-loginurl trigger-save\"  name=\"site-loginurl\" value=\""
+    + alias4(((helper = (helper = helpers.loginurl || (depth0 != null ? depth0.loginurl : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"loginurl","hash":{},"data":data}) : helper)))
+    + "\" placeholder=\""
+    + alias4(((helper = (helper = helpers.loginUrlTXT || (depth0 != null ? depth0.loginUrlTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"loginUrlTXT","hash":{},"data":data}) : helper)))
+    + "\" style=\"width: 160px;\" />\n			</label>\n	<label>\n"
+
+    + "<input type=\"text\" class=\"site-login trigger-save\"  name=\"site-login\" value=\""
+    + alias4(((helper = (helper = helpers.login || (depth0 != null ? depth0.login : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"login","hash":{},"data":data}) : helper)))
+    + "\" placeholder=\""
+    + alias4(((helper = (helper = helpers.loginTXT || (depth0 != null ? depth0.loginTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"loginTXT","hash":{},"data":data}) : helper)))
+    + "\" style=\"width: 160px;\" />\n			</label>\n	<label>\n"
+
+    + "<input type=\"password\" class=\"site-password trigger-save\"  name=\"site-password\" value=\""
+    + alias4(((helper = (helper = helpers.password || (depth0 != null ? depth0.password : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"password","hash":{},"data":data}) : helper)))
+    + "\" placeholder=\""
+    + alias4(((helper = (helper = helpers.passwordTXT || (depth0 != null ? depth0.passwordTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"passwordTXT","hash":{},"data":data}) : helper)))
+    + "\" style=\"width: 160px;\" />\n			</label>\n	<label>\n"
+
+    + "<input type=\"text\" class=\"site-headers trigger-save\"  name=\"site-headers\" value=\""
+    + alias4(((helper = (helper = helpers.headers || (depth0 != null ? depth0.headers : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"headers","hash":{},"data":data}) : helper)))
+    + "\" placeholder=\""
+    + alias4(((helper = (helper = helpers.headersTXT || (depth0 != null ? depth0.headersTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"headersTXT","hash":{},"data":data}) : helper)))
+    + "\" style=\"width: 160px;\" />\n			</label>\n		</div>\n\n		<div>\n			<label>\n				<span>"
+
     + alias4(((helper = (helper = helpers.languageTXT || (depth0 != null ? depth0.languageTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"languageTXT","hash":{},"data":data}) : helper)))
     + "</span>\n				<select class=\"site-lang trigger-save\">\n"
     + ((stack1 = helpers.each.call(alias1,(helpers.getLanguages || (depth0 && depth0.getLanguages) || alias2).call(alias1,(depth0 != null ? depth0.lang : depth0),{"name":"getLanguages","hash":{},"data":data}),{"name":"each","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")

--- a/js/templates/site.handlebars
+++ b/js/templates/site.handlebars
@@ -6,6 +6,15 @@
 	<div class="options hidden">
 		<div>
 			<label>
+				<span>{{authTXT}}</span>
+				<input type="text" name="site-loginurl" class="site-auth trigger-save" value="" style="width: 160px;" />
+				<input type="text" name="site-login" class="site-auth trigger-save" value="" style="width: 160px;" />
+				<input type="password" name="site-password" class="site-auth trigger-save" value="" style="width: 160px;" />
+				<input type="text" name="site-headers" class="site-auth trigger-save" value="" style="width: 160px;" />
+			</label>
+		</div>
+		<div>
+			<label>
 				<span>{{languageTXT}}</span>
 				<select class="site-lang trigger-save">
 					{{#each (getLanguages lang)}}

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -3,6 +3,11 @@ OC.L10N.register(
     {
     "Name" : "Name",
     "URL" : "URL",
+    "Auth" : "Authorization",
+    "Login" : "Login",
+    "LoginUrl" : "Login URL",
+    "Password" : "Password",
+    "Headers" : "Headers",
     "Language" : "Language",
     "Groups" : "Groups",
     "Devices" : "Devices",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -1,7 +1,12 @@
 { "translations": {
     "Name" : "Name",
     "URL" : "URL",
+    "Auth" : "Auth",
+    "LoginUrl" : "Login URL",
+    "Login" : "Login",
+    "Password" : "Password",
     "Language" : "Language",
+    "Headers" : "Headers",
     "Groups" : "Groups",
     "Devices" : "Devices",
     "Icon" : "Icon",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -3,7 +3,12 @@ OC.L10N.register(
     {
     "Name" : "Nom",
     "URL" : "URL",
-    "Language" : "Langue",
+    "Auth" : "Autorisation",
+    "LoginUrl" : "URL",
+    "Login" : "Identifiant",
+    "Password" : "Mot de passe",
+    "Headers" : "En-tête",
+    "Language" : "Langue",    
     "Groups" : "Groupes",
     "Devices" : "Appareils",
     "Icon" : "Icône",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -1,6 +1,11 @@
 { "translations": {
     "Name" : "Nom",
     "URL" : "URL",
+    "Auth" : "Authorisation",
+    "LoginUrl" : "URL",
+    "Login" : "Identifiant",
+    "Password" : "Mot de passe",
+    "Headers" : "En-tête",
     "Language" : "Langue",
     "Groups" : "Groupes",
     "Devices" : "Appareils",

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -146,6 +146,10 @@ class APIController extends OCSController {
 	/**
 	 * @param string $name
 	 * @param string $url
+	 * @param string $loginurl
+	 * @param string $login
+	 * @param string $password
+	 * @param string $headers
 	 * @param string $lang
 	 * @param string $type
 	 * @param string $device
@@ -154,9 +158,9 @@ class APIController extends OCSController {
 	 * @param int $redirect
 	 * @return DataResponse
 	 */
-	public function add($name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function add($name, $url, $loginurl, $login, $password, $headers, $lang, $type, $device, $icon, array $groups, $redirect) {
 		try {
-			return new DataResponse($this->sitesManager->addSite($name, $url, $lang, $type, $device, $icon, $groups, (bool) $redirect));
+			return new DataResponse($this->sitesManager->addSite($name, $url, $loginurl, $login, $password, $headers, $lang, $type, $device, $icon, $groups, (bool) $redirect));
 		} catch (InvalidNameException $e) {
 			return new DataResponse(['error' => $this->l->t('The given label is invalid'), 'field' => 'name'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidURLException $e) {
@@ -178,6 +182,10 @@ class APIController extends OCSController {
 	 * @param int $id
 	 * @param string $name
 	 * @param string $url
+	 * @param string $loginurl
+	 * @param string $login
+	 * @param string $password
+	 * @param string $headers
 	 * @param string $lang
 	 * @param string $type
 	 * @param string $device
@@ -186,9 +194,9 @@ class APIController extends OCSController {
 	 * @param int $redirect
 	 * @return DataResponse
 	 */
-	public function update($id, $name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function update($id, $name, $url, $loginurl, $login, $password, $headers, $lang, $type, $device, $icon, array $groups, $redirect) {
 		try {
-			return new DataResponse($this->sitesManager->updateSite($id, $name, $url, $lang, $type, $device, $icon, $groups, (bool) $redirect));
+			return new DataResponse($this->sitesManager->updateSite($id, $name, $url, $loginurl, $login, $password, $headers, $lang, $type, $device, $icon, $groups, (bool) $redirect));
 		} catch (SiteNotFoundException $e) {
 			return new DataResponse(['error' => $this->l->t('The site does not exist'), 'field' => 'site'], Http::STATUS_NOT_FOUND);
 		} catch (InvalidNameException $e) {

--- a/lib/Controller/SiteController.php
+++ b/lib/Controller/SiteController.php
@@ -129,11 +129,17 @@ class SiteController extends Controller {
 
 		$response = new TemplateResponse('external', 'frame', [
 			'url' => $site['url'],
+			'loginurl' => $site['loginurl'],
+			//'authsecret' => base64_encode($site['login']. ":" . $site['password']),
+			'username' => $site['login'],
+			'password' => $site['password'],
+			'headers' => $site['headers'],
 		], 'user');
 
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedChildSrcDomain('*');
 		$policy->addAllowedFrameDomain('*');
+		$policy->addAllowedConnectDomain('*');
 		$response->setContentSecurityPolicy($policy);
 
 		return $response;

--- a/lib/SitesManager.php
+++ b/lib/SitesManager.php
@@ -197,6 +197,10 @@ class SitesManager {
 	/**
 	 * @param string $name
 	 * @param string $url
+	 * @param string $loginurl
+	 * @param string $login
+	 * @param string $password
+	 * @param string $headers
 	 * @param string $lang
 	 * @param string $type
 	 * @param string $device
@@ -212,7 +216,7 @@ class SitesManager {
 	 * @throws GroupNotFoundException
 	 * @throws IconNotFoundException
 	 */
-	public function addSite($name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function addSite($name, $url, $loginurl, $login, $password, $headers, $lang, $type, $device, $icon, array $groups, $redirect) {
 		$id = 1 + (int) $this->config->getAppValue('external', 'max_site', 0);
 
 		if ($name === '') {
@@ -269,6 +273,10 @@ class SitesManager {
 			'id'   => $id,
 			'name' => $name,
 			'url'  => $url,
+			'loginurl' => $loginurl,
+			'login' => $login,
+			'password' => $password,
+			'headers' => $headers,
 			'lang' => $lang,
 			'type' => $type,
 			'device' => $device,
@@ -286,6 +294,10 @@ class SitesManager {
 	 * @param int $id
 	 * @param string $name
 	 * @param string $url
+	 * @param string $loginurl
+	 * @param string $login
+	 * @param string $password
+	 * @param string $headers
 	 * @param string $lang
 	 * @param string $type
 	 * @param string $device
@@ -302,7 +314,7 @@ class SitesManager {
 	 * @throws GroupNotFoundException
 	 * @throws IconNotFoundException
 	 */
-	public function updateSite($id, $name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function updateSite($id, $name, $url, $loginurl, $login, $password, $headers, $lang, $type, $device, $icon, array $groups, $redirect) {
 		$sites = $this->getSites();
 		if (!isset($sites[$id])) {
 			throw new SiteNotFoundException();
@@ -361,6 +373,10 @@ class SitesManager {
 			'id'   => $id,
 			'name' => $name,
 			'url'  => $url,
+			'loginurl' => $loginurl,
+			'login' => $login,
+			'password' => $password,
+			'headers' => $headers,
 			'lang' => $lang,
 			'type' => $type,
 			'device' => $device,

--- a/templates/frame.php
+++ b/templates/frame.php
@@ -26,4 +26,10 @@ style('external', 'style');
 
 /** @var array $_ */
 ?>
+<!-- <input type="hidden" id="external_authsecret" value="<?php p($_['authsecret']); ?>" /> -->
+<input type="hidden" id="external_url" value="<?php p($_['url']); ?>" />
+<input type="hidden" id="external_loginurl" value="<?php p($_['loginurl']); ?>" />
+<input type="hidden" id="external_username" value="<?php p($_['username']); ?>" />
+<input type="hidden" id="external_password" value="<?php p($_['password']); ?>" />
+<input type="hidden" id="external_headers" value="<?php p($_['headers']); ?>" />
 <iframe id="ifm" src="<?php p($_['url']); ?>"></iframe>


### PR DESCRIPTION
Hi,

I added autentication fields to nextcloud/external.

These authentication fields allow opening external sites protected by a login/password form.

It uses an ajax post request made to an authentication url. Once the authentication is successful and the session cookie has been set, the iframe src attribute is changed to match the external site final url.

Since most of the time the ajax request is performed against an other domain than Nextcloud's one we are confronted to cross sites control restrictions. Thus it is necessary to add Access-Control-Allow-xxxx headers to the web server hosting the external site. The most common necessary headers are those : 
Access-Control-Allow-Origin : "https://external.site.domain"
Access-Control-Allow-Methods : "GET, POST, OPTIONS"
Access-Control-Allow-Credentials: "true"
Access-Control-Allow-Headers: "Authorization, Content-Type"

The fourth field I added is there for supplementary headers sent with the ajax request that might be required by the login form.

I successfully used these auth fields to authenticate against Kibana free edition with x-pack security enabled.

Thank you for taking my contribution into account.

Best regards,

Thierry