### PR TITLE
resize iframe immediately after load, fixes #148

### DIFF
--- a/js/external.js
+++ b/js/external.js
@@ -13,4 +13,5 @@ $(document).ready(function () {
 
 	document.getElementById('ifm').onload = resizeIframe;
 	window.onresize = resizeIframe;
+	resizeIframe();
 });


### PR DESCRIPTION
Not sure whether this is the best way to tackle the issue -- at least I have not found a better JavaScript hook. And it works -- my issue with the page not being full-size from beginning is resolved.

Fix #148 