### PR TITLE
Grant permission for multimedia in the frame

### DIFF
--- a/templates/frame.php
+++ b/templates/frame.php
@@ -26,4 +26,4 @@ style('external', 'style');
 
 /** @var array $_ */
 ?>
-<iframe id="ifm" src="<?php p($_['url']); ?>" allowfullscreen></iframe>
+<iframe id="ifm" src="<?php p($_['url']); ?>" allow="camera; microphone; fullscreen; display-capture"></iframe>


### PR DESCRIPTION
Aside of full-screen, permission for microphone, camera and display capture are granted for use with WebRTC.

Fixes #237 