### PR TITLE
Implementation of Target_Blank option to open External links in a new tab

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,6 +10,10 @@
 	padding: 8px 0;
 }
 
+.site-target-box {
+	padding: 8px 0;
+}
+
 #external .icon-more {
 	width: 16px;
 	height: 16px;

--- a/js/templates/site.handlebars
+++ b/js/templates/site.handlebars
@@ -80,6 +80,16 @@
 			</label>
 		</div>
 
+		<div class="site-target-box">
+			<label>
+				<span>{{targetTXT}}</span>
+				<input type="checkbox" id="site_target_{{id}}" name="site_target_{{id}}"
+					   value="1" class="site-target checkbox trigger-save" {{#if target}} checked="checked"{{/if}} />
+				<label for="site_target_{{id}}">{{OpenTabTXT}}</label>
+			</label>
+		</div>
+
+
 		<div class="button delete-button">{{removeSiteTXT}}</div>
 	</div>
 </li>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -82,7 +82,7 @@ class Application extends App implements IBootstrap {
 				}
 
 				$href = $site['url'];
-				if (!$site['redirect']) {
+				if (!$site['redirect'] && !$site['target']) {
 					$href = $url->linkToRoute('external.site.showPage', ['id'=> $site['id']]);
 				}
 
@@ -93,6 +93,7 @@ class Application extends App implements IBootstrap {
 					'icon' => $image,
 					'type' => $site['type'],
 					'name' => $site['name'],
+					'target' => $site['target'],
 				];
 			});
 		}

--- a/lib/BeforeTemplateRenderedListener.php
+++ b/lib/BeforeTemplateRenderedListener.php
@@ -64,7 +64,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		foreach ($sites as $site) {
 			if ($site['type'] === SitesManager::TYPE_QUOTA) {
 				$link = $site['url'];
-				if (!$site['redirect']) {
+				if (!$site['redirect'] && !$site['target']) {
 					$link = $this->urlGenerator->linkToRoute('external.site.showPage', ['id'=> $site['id']]);
 				}
 
@@ -93,7 +93,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 				}
 
 				$href = $site['url'];
-				if (!$site['redirect']) {
+				if (!$site['redirect'] && !$site['target']) {
 					$href = $this->urlGenerator->linkToRoute('external.site.showPage', ['id'=> $site['id']]);
 				}
 
@@ -104,6 +104,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 					'icon' => $image,
 					'type' => $site['type'],
 					'name' => $site['name'],
+					'target' => $site['target'],
 				];
 			});
 		}

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -43,6 +43,7 @@ class Capabilities implements ICapability {
 					'device',
 					'groups',
 					'redirect',
+					'target'
 				],
 			],
 		];

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -88,6 +88,8 @@ class APIController extends OCSController {
 
 			$site['redirect'] = (int) $site['redirect'];
 
+			$site['target'] = (int) $site['target'];
+
 			unset($site['lang'], $site['device'], $site['groups']);
 			$sites[] = $site;
 		}
@@ -152,11 +154,13 @@ class APIController extends OCSController {
 	 * @param string $icon
 	 * @param string[] $groups
 	 * @param int $redirect
+	 * @param int $target
 	 * @return DataResponse
 	 */
-	public function add($name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function add($name, $url, $lang, $type, $device, $icon, array $groups, $redirect, $target) {
+
 		try {
-			return new DataResponse($this->sitesManager->addSite($name, $url, $lang, $type, $device, $icon, $groups, (bool) $redirect));
+			return new DataResponse($this->sitesManager->addSite($name, $url, $lang, $type, $device, $icon, $groups, (bool) $redirect, (bool) $target));
 		} catch (InvalidNameException $e) {
 			return new DataResponse(['error' => $this->l->t('The given label is invalid'), 'field' => 'name'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidURLException $e) {
@@ -184,11 +188,12 @@ class APIController extends OCSController {
 	 * @param string $icon
 	 * @param string[] $groups
 	 * @param int $redirect
+	 * @param int $target
 	 * @return DataResponse
 	 */
-	public function update($id, $name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function update($id, $name, $url, $lang, $type, $device, $icon, array $groups, $redirect, $target) {
 		try {
-			return new DataResponse($this->sitesManager->updateSite($id, $name, $url, $lang, $type, $device, $icon, $groups, (bool) $redirect));
+			return new DataResponse($this->sitesManager->updateSite($id, $name, $url, $lang, $type, $device, $icon, $groups, (bool) $redirect, (bool) $target));
 		} catch (SiteNotFoundException $e) {
 			return new DataResponse(['error' => $this->l->t('The site does not exist'), 'field' => 'site'], Http::STATUS_NOT_FOUND);
 		} catch (InvalidNameException $e) {

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -56,7 +56,7 @@ class Personal implements ISettings {
 		}
 
 		$url = $quotaLink['url'];
-		if (!$quotaLink['redirect']) {
+		if (!$quotaLink['redirect'] && !$quotaLink['target']) {
 			$url = $this->url->linkToRoute('external.site.showPage', ['id'=> $quotaLink['id']]);
 		}
 

--- a/lib/SitesManager.php
+++ b/lib/SitesManager.php
@@ -184,6 +184,7 @@ class SitesManager {
 				'device' => self::DEVICE_ALL,
 				'groups' => [],
 				'redirect' => false,
+				'target' => false,
 			],
 			$site
 		);
@@ -198,6 +199,7 @@ class SitesManager {
 	 * @param string $icon
 	 * @param string[] $groups
 	 * @param bool $redirect
+	 * @param bool $target
 	 * @return array
 	 * @throws InvalidNameException
 	 * @throws InvalidURLException
@@ -207,7 +209,7 @@ class SitesManager {
 	 * @throws GroupNotFoundException
 	 * @throws IconNotFoundException
 	 */
-	public function addSite($name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function addSite($name, $url, $lang, $type, $device, $icon, array $groups, $redirect, $target) {
 		$id = 1 + (int) $this->config->getAppValue('external', 'max_site', 0);
 
 		if ($name === '') {
@@ -259,6 +261,7 @@ class SitesManager {
 
 		if ($type === self::TYPE_LOGIN) {
 			$redirect = true;
+			$target = true;
 		}
 
 		$sites = $this->getSites();
@@ -272,6 +275,7 @@ class SitesManager {
 			'icon' => $icon,
 			'groups' => $groups,
 			'redirect' => $redirect,
+			'target' => $target
 		];
 		$this->config->setAppValue('external', 'sites', json_encode($sites));
 		$this->config->setAppValue('external', 'max_site', $id);
@@ -289,6 +293,7 @@ class SitesManager {
 	 * @param string $icon
 	 * @param string[] $groups
 	 * @param bool $redirect
+	 * @param bool $target
 	 * @return array
 	 * @throws SiteNotFoundException
 	 * @throws InvalidNameException
@@ -299,7 +304,7 @@ class SitesManager {
 	 * @throws GroupNotFoundException
 	 * @throws IconNotFoundException
 	 */
-	public function updateSite($id, $name, $url, $lang, $type, $device, $icon, array $groups, $redirect) {
+	public function updateSite($id, $name, $url, $lang, $type, $device, $icon, array $groups, $redirect, $target) {
 		$sites = $this->getSites();
 		if (!isset($sites[$id])) {
 			throw new SiteNotFoundException();
@@ -354,6 +359,7 @@ class SitesManager {
 
 		if ($type === self::TYPE_LOGIN) {
 			$redirect = true;
+			$target = true;
 		}
 
 		$sites[$id] = [
@@ -366,6 +372,7 @@ class SitesManager {
 			'icon' => $icon,
 			'groups' => $groups,
 			'redirect' => $redirect,
+			'target' => $target
 		];
 		$this->config->setAppValue('external', 'sites', json_encode($sites));
 

--- a/src/admin.js
+++ b/src/admin.js
@@ -106,6 +106,8 @@ import { generateUrl, imagePath, generateOcsUrl } from '@nextcloud/router';
 			data.iconTXT = t('external', 'Icon')
 			data.positionTXT = t('external', 'Position')
 			data.redirectTXT = t('external', 'Redirect')
+			data.targetTXT = t('external', 'New Tab')
+			data.OpenTabTXT = t('external', 'External links open in a new tab')
 			data.removeSiteTXT = t('external', 'Remove site')
 			data.noEmbedTXT = t('external', 'This site does not allow embedding')
 			data.deleteIMG = imagePath('core', 'actions/delete.svg')
@@ -173,6 +175,7 @@ import { generateUrl, imagePath, generateOcsUrl } from '@nextcloud/router';
 				self._attachEvents($el)
 				if (site.attributes.type === 'guest') {
 					$el.find('.site-redirect-box').hide()
+					$el.find('.site-target-box').hide()
 				}
 				self.$list.append($el)
 			})
@@ -231,6 +234,7 @@ import { generateUrl, imagePath, generateOcsUrl } from '@nextcloud/router';
 				type: $site.find('.site-type').val(),
 				device: $site.find('.site-device').val(),
 				redirect: $site.find('.site-redirect').prop('checked') ? 1 : 0,
+				target: $site.find('.site-target').prop('checked') ? 1 : 0,
 				groups: groups === '' ? [] : groups.split('|'),
 				icon: $site.find('.site-icon').val(),
 			}
@@ -239,8 +243,10 @@ import { generateUrl, imagePath, generateOcsUrl } from '@nextcloud/router';
 			$site.find('.invalid-value').removeClass('invalid-value')
 			if (data.type === 'guest') {
 				$site.find('.site-redirect-box').hide()
+				$site.find('.site-target-box').hide()
 			} else {
 				$site.find('.site-redirect-box').show()
+				$site.find('.site-target-box').show()
 			}
 
 			if (!_.isUndefined(site)) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/external/issues/79
** External Issue :  #74 "Open in new tab"**

Hi !

We are a team that contributes to the improvement and production of free software for the general public. Moreover, being a NextCloud user, we wanted to improve it and especially the External module.

Thus, we wanted to respond to Issue #74 which requires the opening of external links to a new tab.
We have therefore improved the source code of the External module by modifying the following:

On External front-end, we added the possibility to check the "New Tab" option. 
We have modified the files **"admin.js", "site.handlebars" and "style.css"** in the External module where we added a "target" option. 
**But we needed to modify some Nextcloud files too : "layout.user.php" and "MainMenu.js". So we also made a contribution on NextCloud Server in order for the implementation to be done properly.**

For setting up the data option in the database and link the front-end to back-end, we had to modify the following files in External module : 
**"Application.php", "APIController.php", "SitesManager.php", "Personnal.php", "BeforeTemplateRenderedListener.php" and " Capabilites.php"**.
In all of this files, we added the "target" option which allows us to follow the activation of the front-end option to the back-end and the database. 

If you have any questions about the implementation of the option, please do not hesitate to contact us by email at the following address: contact@fcclvandoeuvre.fr or christophecanovas66@gmail.com.

Regards, 


/!\ Careful /!\

The compatibility between the "redirect" option and the "target" option can sometimes create a bug and are not necessarily compatible. But the use of both options at the same time is possible and feature on mozilla/firefox/chrome. However, it is preferable to use either option and not both at the same time.

/!\ Careful /!\