### PR TITLE
Fix passing null to urlencode

### DIFF
--- a/lib/SitesManager.php
+++ b/lib/SitesManager.php
@@ -121,9 +121,10 @@ class SitesManager {
 			$groups = [];
 		}
 
-		$email= $user instanceof IUser ? $user->getEMailAddress() : '';
+		$email = $user instanceof IUser ? $user->getEMailAddress() : '';
 		$uid  = $user instanceof IUser ? $user->getUID() : '';
 		$displayName = $user instanceof IUser ? $user->getDisplayName() : '';
+		$email = $email ?? '';
 
 		$langSites = [];
 		foreach ($sites as $id => $site) {


### PR DESCRIPTION
urlencode(): Passing null to parameter #1 ($string) of type string is deprecated at /srv/http/nc/apps/external/lib/SitesManager.php#144"

