### PR TITLE
[stable25] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -133,12 +133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6ee42ac471622be945e2396791f968d9345a1e06"
+                "reference": "df0721aa5be775c341a84962aeb0b51b8d6219db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6ee42ac471622be945e2396791f968d9345a1e06",
-                "reference": "6ee42ac471622be945e2396791f968d9345a1e06",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/df0721aa5be775c341a84962aeb0b51b8d6219db",
+                "reference": "df0721aa5be775c341a84962aeb0b51b8d6219db",
                 "shasum": ""
             },
             "require": {
@@ -168,7 +168,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable25"
             },
-            "time": "2023-03-31T00:37:20+00:00"
+            "time": "2023-07-07T00:44:44+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency