### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562"
+                "reference": "50152a7077733dca92e9842a77e928eebe4b6e60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
-                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/50152a7077733dca92e9842a77e928eebe4b6e60",
+                "reference": "50152a7077733dca92e9842a77e928eebe4b6e60",
                 "shasum": ""
             },
             "require": {
@@ -169,7 +169,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-07-17T09:26:46+00:00"
+            "time": "2023-08-03T00:37:29+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency