### PR TITLE
feat: forward url path segments to iframe

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -22,10 +22,10 @@
 return [
 	'routes' => [
 		['name' => 'site#showDefaultPage', 'url' => '/', 'verb' => 'GET'],
-		['name' => 'site#showPage', 'url' => '/{id}', 'verb' => 'GET'],
 		['name' => 'icon#uploadIcon', 'url' => '/icons', 'verb' => 'POST'],
 		['name' => 'icon#showIcon', 'url' => '/icons/{icon}', 'verb' => 'GET'],
 		['name' => 'icon#deleteIcon', 'url' => '/icons/{icon}', 'verb' => 'DELETE'],
+		['name' => 'site#showPage', 'url' => '/{id}/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.*']],
 	],
 	'ocs' => [
 		['name' => 'API#get', 'url' => '/api/{apiVersion}', 'verb' => 'GET', 'requirements' => ['apiVersion' => 'v1']],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -82,7 +82,7 @@ class Application extends App implements IBootstrap {
 
 				$href = $site['url'];
 				if (!$site['redirect']) {
-					$href = $url->linkToRoute('external.site.showPage', ['id' => $site['id']]);
+					$href = $url->linkToRoute('external.site.showPage', ['id' => $site['id'], 'path' => '']);
 				}
 
 				return [

--- a/lib/BeforeTemplateRenderedListener.php
+++ b/lib/BeforeTemplateRenderedListener.php
@@ -97,7 +97,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 
 	protected function getHref(array $site): string {
 		if (!$site['redirect']) {
-			return $this->urlGenerator->linkToRoute('external.site.showPage', ['id' => $site['id']]);
+			return $this->urlGenerator->linkToRoute('external.site.showPage', ['id' => $site['id'], 'path' => '']);
 		}
 
 		return $site['url'];

--- a/lib/Controller/SiteController.php
+++ b/lib/Controller/SiteController.php
@@ -61,10 +61,10 @@ class SiteController extends Controller {
 	 *
 	 * @return TemplateResponse|RedirectResponse
 	 */
-	public function showPage(int $id) {
+	public function showPage(int $id, string $path) {
 		try {
 			$site = $this->sitesManager->getSiteById($id);
-			return $this->createResponse($id, $site);
+			return $this->createResponse($id, $site, $path);
 		} catch (SiteNotFoundException $e) {
 			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
@@ -100,11 +100,16 @@ class SiteController extends Controller {
 		return new RedirectResponse($this->url->getAbsoluteURL('/index.php/apps/files/'));
 	}
 
-	protected function createResponse(int $id, array $site): TemplateResponse {
+	protected function createResponse(int $id, array $site, string $path = ''): TemplateResponse {
 		$this->navigationManager->setActiveEntry('external_index' . $id);
 
+		if ($path !== '') {
+			// Check whether we need to suffix the site URL with a slash, or not.
+			$path = $site['url'][-1] == '/' ? $path : '/' . $path;
+		}
+
 		$response = new TemplateResponse('external', 'frame', [
-			'url' => $site['url'],
+			'url' => $site['url'] . $path,
 			'name' => $site['name'],
 		], 'user');
 

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -56,7 +56,7 @@ class Personal implements ISettings {
 
 		$url = $quotaLink['url'];
 		if (!$quotaLink['redirect']) {
-			$url = $this->url->linkToRoute('external.site.showPage', ['id' => $quotaLink['id']]);
+			$url = $this->url->linkToRoute('external.site.showPage', ['id' => $quotaLink['id'], 'path' => '']);
 		}
 
 		return new TemplateResponse('external', 'quota', [

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -36,6 +36,7 @@ script('external', 'templates');
 		<h2><?php p($l->t('External sites'));?></h2>
 		<p class="settings-hint"><?php p($l->t('Add a website directly to the app list in the top bar. This will be visible for all users and is useful to quickly reach other internally used web apps or important sites.')); ?></p>
 		<p class="settings-hint"><?php p($l->t('The placeholders {email}, {uid} and {displayname} can be used and are filled with the user´s values to customize the links.')); ?></p>
+		<p class="settings-hint"><?php p($l->t("When accessing the external site through the Nextcloud link, path parameters will be forwarded to the external site. So you can also create deep links (e.g. 'mycloud.com/external/1/pageA' will lead to Nextcloud with the iframe pointed at 'externalsite.com/pageA').")); ?></p>
 		<p class="settings-hint"><?php print_unescaped(str_replace(
 			['{linkstart}', '{linkend}'],
 			['<a target="_blank" class="external" href="https://github.com/nextcloud/external/blob/master/docs/jwt-sample.php" rel="noreferrer nofollow">', ' ↗</a>'],


### PR DESCRIPTION
- allow URL parameters and path segments to be forwarded to the included iframe (e.g. trying to open `www.mycloud.com/external/1/subpage` will properly forward the `subpage` path segment to your embedded page)

closes #479 