### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "50152a7077733dca92e9842a77e928eebe4b6e60"
+                "reference": "e190b8f76e21b46d921f61883b88f18ca4e7b8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/50152a7077733dca92e9842a77e928eebe4b6e60",
-                "reference": "50152a7077733dca92e9842a77e928eebe4b6e60",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e190b8f76e21b46d921f61883b88f18ca4e7b8a1",
+                "reference": "e190b8f76e21b46d921f61883b88f18ca4e7b8a1",
                 "shasum": ""
             },
             "require": {
@@ -169,7 +169,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-08-03T00:37:29+00:00"
+            "time": "2023-10-04T09:19:39+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency