### PR TITLE
feat: groups placeholder

### DIFF
--- a/lib/SitesManager.php
+++ b/lib/SitesManager.php
@@ -151,8 +151,8 @@ class SitesManager {
 			}
 
 			$site['url'] = str_replace(
-				['{email}', '{uid}', '{displayname}', '{jwt}'],
-				array_map('rawurlencode', [$email, $uid, $displayName, $jwt]),
+				['{email}', '{uid}', '{displayname}', '{jwt}', '{groups}'],
+				array_map('rawurlencode', [$email, $uid, $displayName, $jwt, implode(",", $groups)]),
 				$site['url']
 			);
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -35,7 +35,7 @@ script('external', 'templates');
 	<div class="section">
 		<h2><?php p($l->t('External sites'));?></h2>
 		<p class="settings-hint"><?php p($l->t('Add a website directly to the app list in the top bar. This will be visible for all users and is useful to quickly reach other internally used web apps or important sites.')); ?></p>
-		<p class="settings-hint"><?php p($l->t('The placeholders {email}, {uid} and {displayname} can be used and are filled with the user´s values to customize the links.')); ?></p>
+		<p class="settings-hint"><?php p($l->t('The placeholders {email}, {uid}, {displayname} and {groups} can be used and are filled with the user´s values to customize the links.')); ?></p>
 		<p class="settings-hint"><?php p($l->t("When accessing the external site through the Nextcloud link, path parameters will be forwarded to the external site. So you can also create deep links (e.g. 'mycloud.com/external/1/pageA' will lead to Nextcloud with the iframe pointed at 'externalsite.com/pageA').")); ?></p>
 		<p class="settings-hint"><?php print_unescaped(str_replace(
 			['{linkstart}', '{linkend}'],


### PR DESCRIPTION
- new version of my last pr #579 (sorry, messed up the rebasing)
- allow `{groups}` as a dynamic placeholder for external sites (this is a very common scenario to do something/change content on the external site based on group membership)
- `groups` array elements will be joined with a comma and then url-encoded