### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "a8d9ce428b47455b4bd30170ae95c322cdbef6f6"
+                "reference": "80cdd62e56c7bf54d35ea2f012786e6cf7d4de27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a8d9ce428b47455b4bd30170ae95c322cdbef6f6",
-                "reference": "a8d9ce428b47455b4bd30170ae95c322cdbef6f6",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/80cdd62e56c7bf54d35ea2f012786e6cf7d4de27",
+                "reference": "80cdd62e56c7bf54d35ea2f012786e6cf7d4de27",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-03-05T00:31:32+00:00"
+            "time": "2024-04-06T00:32:02+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency