### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e96b76eddd4c1bea60d41da1e20835806d62923e"
+                "reference": "1c0336e8d268afa7accafe096b52cc6fe2c694d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e96b76eddd4c1bea60d41da1e20835806d62923e",
-                "reference": "e96b76eddd4c1bea60d41da1e20835806d62923e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1c0336e8d268afa7accafe096b52cc6fe2c694d1",
+                "reference": "1c0336e8d268afa7accafe096b52cc6fe2c694d1",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-06-06T00:35:15+00:00"
+            "time": "2024-06-14T00:35:47+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency