### PR TITLE
[stable30] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "65bc71ed71b10f60394e3a3165f27e78e6b087cb"
+                "reference": "f2be8ca227b71a2f9d0b025d231e4eb49d21c61c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/65bc71ed71b10f60394e3a3165f27e78e6b087cb",
-                "reference": "65bc71ed71b10f60394e3a3165f27e78e6b087cb",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f2be8ca227b71a2f9d0b025d231e4eb49d21c61c",
+                "reference": "f2be8ca227b71a2f9d0b025d231e4eb49d21c61c",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2024-08-31T00:39:39+00:00"
+            "time": "2024-09-05T00:40:13+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency