### PR TITLE
[stable30] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ca90c242611224a490eb5cadff885ab4305a4df9"
+                "reference": "245f3243410e0f21cab9375375d289e6e5b6df97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ca90c242611224a490eb5cadff885ab4305a4df9",
-                "reference": "ca90c242611224a490eb5cadff885ab4305a4df9",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/245f3243410e0f21cab9375375d289e6e5b6df97",
+                "reference": "245f3243410e0f21cab9375375d289e6e5b6df97",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2024-09-18T00:40:48+00:00"
+            "time": "2024-09-26T00:42:25+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency