### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "a1bbdf6404904379aad66ed6487218b0f264eead"
+                "reference": "10e994eb1a55e3639924bc11d33f9903ca971e57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a1bbdf6404904379aad66ed6487218b0f264eead",
-                "reference": "a1bbdf6404904379aad66ed6487218b0f264eead",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/10e994eb1a55e3639924bc11d33f9903ca971e57",
+                "reference": "10e994eb1a55e3639924bc11d33f9903ca971e57",
                 "shasum": ""
             },
             "require": {
@@ -174,7 +174,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-02-20T00:44:12+00:00"
+            "time": "2025-02-26T00:44:23+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency