### PR TITLE
hash routing support

### DIFF
--- a/js/external.js
+++ b/js/external.js
@@ -14,4 +14,8 @@ $(document).ready(function () {
 	document.getElementById('ifm').onload = resizeIframe;
 	window.onresize = resizeIframe;
 	resizeIframe();
+	// hash routing support
+	if(window.location.hash && window.location.hash.length) {
+		document.getElementById('ifm').src = document.getElementById('ifm').src + window.location.hash;
+	}
 });

--- a/js/external.js
+++ b/js/external.js
@@ -16,6 +16,16 @@ $(document).ready(function () {
 	resizeIframe();
 	// hash routing support
 	if(window.location.hash && window.location.hash.length) {
-		document.getElementById('ifm').src = document.getElementById('ifm').src + window.location.hash;
+		updateHash();
+	}
+
+	window.addEventListener("hashchange", function(event) {
+		updateHash();
+	});
+
+	function updateHash() {
+		const iframeURL = new URL(document.getElementById('ifm').src);
+		iframeURL.hash = window.location.hash;
+		document.getElementById('ifm').src = iframeURL.toString();
 	}
 });


### PR DESCRIPTION
Some SPAs (e.g. Zammad), use hash routing (e.g. /#ticket/...). With this change you can have working internal routing for links like `https://my.nextcloud.com/apps/external/1/#ticket/zoom/102`