### PR TITLE
[stable30] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5f9528ff4f83ee55bb69630fee7d0f3fc9a64a86"
+                "reference": "d6000d61d8ae708199bd90e1da0c794712c81030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5f9528ff4f83ee55bb69630fee7d0f3fc9a64a86",
-                "reference": "5f9528ff4f83ee55bb69630fee7d0f3fc9a64a86",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d6000d61d8ae708199bd90e1da0c794712c81030",
+                "reference": "d6000d61d8ae708199bd90e1da0c794712c81030",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable30"
             },
-            "time": "2025-03-05T00:45:45+00:00"
+            "time": "2025-03-31T13:55:31+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency