### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f54b33ec39e71dfd8376e5be4e9d97cc55245a48"
+                "reference": "7e54c6d7f0f3880b3af30b58e0730d3da87c99e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f54b33ec39e71dfd8376e5be4e9d97cc55245a48",
-                "reference": "f54b33ec39e71dfd8376e5be4e9d97cc55245a48",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/7e54c6d7f0f3880b3af30b58e0730d3da87c99e0",
+                "reference": "7e54c6d7f0f3880b3af30b58e0730d3da87c99e0",
                 "shasum": ""
             },
             "require": {
@@ -174,7 +174,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-03-20T00:45:48+00:00"
+            "time": "2025-04-02T00:48:32+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency