### PR TITLE
fix: prevent unsupported global app group restriction

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,14 +20,14 @@ More information is available in the External sites documentation.]]></descripti
 	<author>Joas Schilling</author>
 
 	<namespace>External</namespace>
+	
+	<types>
+		<prevent_group_restriction/>
+	</types>
 
 	<documentation>
 		<admin>https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/external_sites.html</admin>
 	</documentation>
-
-	<types>
-		<prevent_group_restriction/>
-	</types>
 
 	<category>customization</category>
 	<category>integration</category>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,6 +25,10 @@ More information is available in the External sites documentation.]]></descripti
 		<admin>https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/external_sites.html</admin>
 	</documentation>
 
+	<types>
+		<prevent_group_restriction/>
+	</types>
+
 	<category>customization</category>
 	<category>integration</category>
 	<category>tools</category>


### PR DESCRIPTION
Fixes #307

Not currently supported and breaks things in Web UI (and presumably Desktop & Mobile clients).