### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f2c9631628aa505923ea9da8e94cbbaccff42207"
+                "reference": "9233dca15337018ec742c01063b58cd858020797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f2c9631628aa505923ea9da8e94cbbaccff42207",
-                "reference": "f2c9631628aa505923ea9da8e94cbbaccff42207",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9233dca15337018ec742c01063b58cd858020797",
+                "reference": "9233dca15337018ec742c01063b58cd858020797",
                 "shasum": ""
             },
             "require": {
@@ -174,7 +174,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-10-08T00:46:58+00:00"
+            "time": "2025-10-15T00:49:39+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency