### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -134,12 +134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d23138a46126bef1f3aea157a80c53638d8e37b7"
+                "reference": "e865caa380ec8f82800b821bff4cd095669f760d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d23138a46126bef1f3aea157a80c53638d8e37b7",
-                "reference": "d23138a46126bef1f3aea157a80c53638d8e37b7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e865caa380ec8f82800b821bff4cd095669f760d",
+                "reference": "e865caa380ec8f82800b821bff4cd095669f760d",
                 "shasum": ""
             },
             "require": {
@@ -174,7 +174,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2026-03-20T01:09:10+00:00"
+            "time": "2026-03-27T01:17:34+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency