### PR TITLE
build(krankerl): Add missing lib/Vendor

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -3,5 +3,6 @@
 [package]
 before_cmds = [
 	'npm ci',
-	'npm run build'
+	'npm run build',
+	'composer install --no-dev',
 ]


### PR DESCRIPTION
`Class \"OCA\\External\\Vendor\\Firebase\\JWT\\JWT\" not found`

Krankerl doesn't copy the gitignored lib/Vendor, so it needs to run `composer install --no-dev` again.