### PR TITLE
Fix dark/light icon variant for External links in the Settings menu

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -63,12 +63,21 @@ class Application extends App implements IBootstrap {
 				continue;
 			}
 
-			$navigationManager->add(function () use ($site, $url): array {
-				if ($site['icon'] !== '') {
-					$image = $url->linkToRoute('external.icon.showIcon', ['icon' => $site['icon']]);
-				} else {
-					$image = $url->linkToRoute('external.icon.showIcon', ['icon' => 'external.svg']);
+			$navigationManager->add(function () use ($site, $url, $sitesManager): array {
+				$icon = $site['icon'] !== '' ? $site['icon'] : 'external.svg';
+
+				// Settings-menu entries are recoloured by Nextcloud core via the
+				// `--background-invert-if-dark` CSS filter, which expects a
+				// dark-coloured source icon. Prefer the paired `-dark` variant
+				// so the icon stays visible in the dark theme (nextcloud/external#430).
+				if ($site['type'] === SitesManager::TYPE_SETTING && !str_contains($icon, '-dark.')) {
+					$darkIcon = preg_replace('/(\.[^.]+)$/', '-dark$1', $icon);
+					if (is_string($darkIcon) && in_array($darkIcon, $sitesManager->getAvailableIcons(), true)) {
+						$icon = $darkIcon;
+					}
 				}
+
+				$image = $url->linkToRoute('external.icon.showIcon', ['icon' => $icon]);
 
 				$href = $site['url'];
 				if (!$site['redirect']) {

--- a/lib/BeforeTemplateRenderedListener.php
+++ b/lib/BeforeTemplateRenderedListener.php
@@ -89,7 +89,20 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			}
 
 			$this->navigationManager->add(function () use ($site) {
-				$image = $this->generateImageLink($site, false);
+				$icon = $site['icon'] !== '' ? $site['icon'] : 'external.svg';
+
+				// Settings-menu entries are recoloured by Nextcloud core via the
+				// `--background-invert-if-dark` CSS filter, which expects a
+				// dark-coloured source icon. Prefer the paired `-dark` variant
+				// so the icon stays visible in the dark theme (nextcloud/external#430).
+				if ($site['type'] === SitesManager::TYPE_SETTING && !str_contains($icon, '-dark.')) {
+					$darkIcon = preg_replace('/(\.[^.]+)$/', '-dark$1', $icon);
+					if (is_string($darkIcon) && in_array($darkIcon, $this->sitesManager->getAvailableIcons(), true)) {
+						$icon = $darkIcon;
+					}
+				}
+
+				$image = $this->urlGenerator->linkToRoute('external.icon.showIcon', ['icon' => $icon, 'dark' => false]);
 				$href = $this->getHref($site);
 
 				return [


### PR DESCRIPTION
### Problem

External links configured with position `settings` used the wrong icon
variant in Nextcloud's account and Settings menus.

For a paired icon such as `audiobookshelf.svg` / `audiobookshelf-dark.svg`,
the base filename `audiobookshelf.svg` was always registered. Nextcloud's
Settings menu then applies its own theme-dependent filter:

    filter: var(--background-invert-if-dark);

In the dark theme this inverts the source icon. Because the source was
already the light-coloured icon, it was inverted to black and became hard
or impossible to see against the dark menu background.

### Root cause

External registers the same navigation entry in two places:

- `Application::registerSites()`
- `BeforeTemplateRenderedListener::generateNavigationLinks()`

Both supplied the configured base filename for Settings entries, so a fix
in only one file had no visible effect.

### Change

For entries of type `SitesManager::TYPE_SETTING`, the registration code now:

1. Reads the configured icon filename (or `external.svg`).
2. Derives the paired dark filename by inserting `-dark` before the extension.
3. Uses it **only if that file exists** in the app data icon directory.
4. Falls back to the configured icon otherwise.
5. Skips derivation if the admin already chose a `-dark.` icon (avoids `foo-dark-dark.svg`).

Header links, guest/login links, public footer links and quota icons are
unchanged. The same block is applied in both registration paths.

### Why this works

`-dark` is the dark-coloured source asset. In the Settings menu the light
theme shows it unchanged, and the dark theme applies core's existing
inversion to produce a light icon — matching core's rendering rather than
adding theme detection inside External.

### Scope / non-goals

Does not change header, footer, quota, mobile/desktop client icon selection,
stored site config, or icon upload. Full-colour (non-monochrome) icons can
still be affected by core's inversion; this follows the app's existing paired
monochrome-icon convention and does not claim to solve arbitrary coloured icons.

### Follow-ups (not in this PR, to keep it targeted)

- Extract the selection into a shared method/service so the two paths can't diverge.
- Read the icon directory listing at most once per request.
- Unit tests for the pairing/fallback cases.

### Standards checked

- [x] DCO sign-off added to the commit
- [x] Coding standard (php-cs-fixer, Nextcloud ruleset) — ran locally, no violations
- [x] PHP lint (`php -l`) passes on both changed files
- [x] REUSE / license headers — no new files added, existing headers untouched
- [x] info.xml lint — file not touched
- [ ] Psalm — not run locally (separate toolchain + baseline); change is trivially typed, will be verified by CI
- [ ] PHPUnit — no test changes; no existing unit tests exercise this path

### Testing

- Light theme shows the dark-coloured icon correctly.
- Dark theme shows a light icon after core's CSS inversion.
- Account menu receives `/apps/external/icons/audiobookshelf-dark.svg` instead of `audiobookshelf.svg`.
- Header / non-Settings entries unchanged; falls back to base icon when no `-dark` pair exists.
- `php -l` and php-cs-fixer pass on both changed files.

This change was AI-assisted and validated on Nextcloud 34.0.1.

Fixes #430
